### PR TITLE
Add key-level locking

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -7,13 +7,18 @@ import (
 )
 
 func main() {
-	fsvault.Put("testkey2", []byte("test data"))
 
-	lock, data, err := fsvault.GetWithLock("testkey")
-	defer lock.Unlock()
-	if err != nil {
-		log.Println(err)
-	}
+	// put some initial data on file
+	fsvault.Put("mysecret", []byte("the wind blows from above"))
 
+	// simply read the data back
+	data, _ := fsvault.Get("mysecret")
 	log.Println("got data:", string(data))
+
+	// read the data WithLock when making a change
+	lock, data, _ := fsvault.GetWithLock("mysecret")
+	defer lock.Unlock()
+
+	// now write a new secret
+	fsvault.Put("mysecret", []byte("the wind blows from below"))
 }

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"log"
+
+	"github.com/thisdougb/go-fsvault/fsvault"
+)
+
+func main() {
+	fsvault.Put("testkey2", []byte("test data"))
+
+	lock, data, err := fsvault.GetWithLock("testkey")
+	defer lock.Unlock()
+	if err != nil {
+		log.Println(err)
+	}
+
+	log.Println("got data:", string(data))
+}

--- a/fsvault/fsvault.go
+++ b/fsvault/fsvault.go
@@ -167,6 +167,16 @@ func Put(key string, data []byte) error {
 	return nil
 }
 
+// GetWithLock returns a locked mutex with the data, enabling synchronised
+// key updates.
+func GetWithLock(key string) (Unlocker, []byte, error) {
+
+	lock := keylocker.lock("test")
+	data, err := Get(key)
+
+	return lock, data, err
+}
+
 // Get returns the data at key, or an error.
 //
 // If encryption keys are present, and a non-primary encryption key successfully

--- a/fsvault/fsvault.go
+++ b/fsvault/fsvault.go
@@ -15,29 +15,15 @@ package fsvault
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"slices"
 	"strings"
-	"time"
 
 	"github.com/thisdougb/go-fsvault/internal/encryption"
 	"github.com/thisdougb/go-fsvault/internal/filedata"
-	"github.com/thisdougb/go-fsvault/internal/logger"
 )
-
-// log is a type alias to avoid exporting Logger
-type logAlias = logger.Logger
-
-// FSVault puts and gets data objects in the datastore under `location` on the
-// filesystem.
-type FSVault struct {
-	location       string
-	encryptionKeys []string
-	cipher         string
-	logAlias
-}
 
 // The default filesystem permissions, need to be permissive enough if using
 // imported fsvault and the cli. Balance access control with encryption use.
@@ -46,48 +32,19 @@ var (
 	defaultDirectoryPerm = os.FileMode(0754)
 )
 
-/*
-NewFSVault returns an FSVault instance ready to use.
-
-The location is the root path on the filesystem, under which all keys will be
-stored. Using a root namepsace is generally a nice safety feature, to avoid
-polluing the filesystem by accident.
-
-Passing a list of suitable keys (32-char) enables encryption data on-the-fly.
-The first key in the list is considered primary, and always used when putting
-data.
-*/
-func NewFSVault(location string, encryptionKeys ...string) *FSVault {
-
-	f := &FSVault{}
-	f.location = location
-	f.logAlias.TimeCreated = time.Now()
-	f.logAlias.LogId = "fsvault"
-
-	// only one cipher mode at the moment
-	if len(encryptionKeys) > 0 && encryptionKeys[0] != "" {
-		f.encryptionKeys = encryptionKeys
-		f.cipher = "AES-GCM"
-	}
-
-	return f
-}
+var (
+	cipher = "AES-GCM"
+)
 
 // FullFilePath returns the filesystem path to the data file for key
-func (f *FSVault) FullFilePath(key string) string {
-	return filepath.Join(f.location, filepath.Clean(key))
-}
-
-// EnableDebug turns on extra debugging messages, perhaps most useful for the
-// cli.
-func (f *FSVault) EnableDebug() {
-	f.logAlias.Debug = true
+func fullFilePath(key string) string {
+	return filepath.Join(datadir, filepath.Clean(key))
 }
 
 // KeyExists returns true if data exists at key, and is read/writeable.
-func (f *FSVault) KeyExists(key string) (bool, error) {
+func KeyExists(key string) (bool, error) {
 
-	fullPath := f.FullFilePath(key)
+	fullPath := fullFilePath(key)
 
 	info, err := os.Stat(fullPath)
 	if err != nil {
@@ -110,18 +67,12 @@ func (f *FSVault) KeyExists(key string) (bool, error) {
 /*
 Delete removes the file or directory (if empty) at key.
 */
-func (f *FSVault) Delete(key string) error {
+func Delete(key string) error {
 
-	loggerName := "fsvault.Delete()"
-
-	fullPath := f.FullFilePath(key)
+	fullPath := fullFilePath(key)
 
 	err := os.Remove(fullPath)
 	if err != nil {
-		f.LogDebug(fmt.Sprintf("%s: %s",
-			loggerName,
-			err.Error()))
-
 		if strings.Contains(err.Error(), "no such file or directory") {
 			return errors.New("key does not exist")
 		}
@@ -130,34 +81,25 @@ func (f *FSVault) Delete(key string) error {
 		}
 		return err
 	}
-
 	return nil
 }
 
 /*
 List returns an alphabetically sorted list of the object names found a key.
 */
-func (f *FSVault) List(key string) []string {
-
-	loggerName := "fsvault.List()"
+func List(key string) []string {
 
 	keysFound := []string{}
 
-	fullPath := f.FullFilePath(key)
+	fullPath := fullFilePath(key)
 
 	dir, err := os.Open(fullPath)
 	if err != nil {
-		f.LogDebug(fmt.Sprintf("%s: %s",
-			loggerName,
-			err.Error()))
 		return keysFound
 	}
 
 	files, err := dir.ReadDir(-1)
 	if err != nil {
-		f.LogDebug(fmt.Sprintf("%s: %s",
-			loggerName,
-			err.Error()))
 		return keysFound
 	}
 
@@ -178,15 +120,13 @@ func (f *FSVault) List(key string) []string {
 //
 // If encryption keys are present then the primary (first) key is used to
 // encrypt the data.
-func (f *FSVault) Put(key string, data []byte) error {
+func Put(key string, data []byte) error {
 
-	loggerName := "fsvault.Put()"
-
-	fullPath := f.FullFilePath(key)
+	fullPath := fullFilePath(key)
 
 	// slight of hand here. we are really only checking if we can't write to
 	// this key. we don't care if there's a file there already, or not.
-	_, err := f.KeyExists(fullPath)
+	_, err := KeyExists(fullPath)
 	if err != nil {
 		switch err.(type) {
 		case *os.PathError:
@@ -198,32 +138,16 @@ func (f *FSVault) Put(key string, data []byte) error {
 
 	fd := filedata.FileData{}
 	fd.Data = data
-	fd.Cipher = f.cipher
+	fd.Cipher = cipher
 
-	if f.cipher != "" && len(f.encryptionKeys) > 0 {
+	if cipher != "" && len(encryptionKeys) > 0 {
 
-		cipherData, err := encryption.Encrypt(f.encryptionKeys[0], data)
+		cipherData, err := encryption.Encrypt(encryptionKeys[0], data)
 		if err != nil {
-
-			// permanent error, so tell the user
-			if err.Error() == "crypto/aes: invalid key size 8" {
-
-				f.LogError(fmt.Sprintf("%s: invalid encryption key length %s",
-					loggerName,
-					f.encryptionKeys[0]))
-			}
-
 			return err
 		}
 
 		fd.Data = cipherData
-
-		f.LogDebug(fmt.Sprintf("%s: encrypted data at key %s",
-			loggerName,
-			key))
-
-	} else {
-		f.LogDebug(fmt.Sprintf("%s: encryption not enabled", loggerName))
 	}
 
 	fdJSON, _ := json.Marshal(fd)
@@ -248,86 +172,51 @@ func (f *FSVault) Put(key string, data []byte) error {
 // If encryption keys are present, and a non-primary encryption key successfully
 // decrypted the data, then the data is re-stored using the primary encryption
 // key. See the main documentation for more on encryption key rollover.
-func (f *FSVault) Get(key string) ([]byte, error) {
+func Get(key string) ([]byte, error) {
 
-	loggerName := "fsvault.Get()"
-
-	fullPath := f.FullFilePath(key)
+	fullPath := fullFilePath(key)
 
 	fd := &filedata.FileData{}
 
 	filecontent, err := os.ReadFile(fullPath)
 	if err != nil {
-		f.LogDebug(
-			fmt.Sprintf("%s: error %s", loggerName, err.Error()))
-
 		return fd.Data, err
 	}
 
 	err = json.Unmarshal([]byte(filecontent), fd)
 	if err != nil {
-		f.LogDebug(
-			fmt.Sprintf("%s: %s", loggerName, err.Error()))
 		return fd.Data, err
 	}
 
 	if fd.Cipher != "" {
 
 		// encryptionKey[0] is the most current
-		for i, encryptionKey := range f.encryptionKeys {
+		for i, encryptionKey := range encryptionKeys {
 
 			decryptedData, err := encryption.Decrypt(encryptionKey, fd.Data)
 
 			if err != nil {
 
-				// permanent error, so tell the user and return
-				if err.Error() == "crypto/aes: invalid key size 8" {
-
-					f.LogDebug(
-						fmt.Sprintf("%s: invalid encryption key length %s",
-							loggerName,
-							encryptionKey))
-
-					return fd.Data, err
-				}
-
-				f.LogDebug(
-					fmt.Sprintf("%s: decrypt error with key %d = %s",
-						loggerName,
-						i,
-						err.Error()))
-
 				// if we tried all the keys, we can't decrypt
-				if i == len(f.encryptionKeys)-1 {
+				if i == len(encryptionKeys)-1 {
 					return fd.Data, err
 				}
 
-				// decryption failed, assume another encryptionKey may work
+				// decryption failed, try the next available key
 				continue
 			}
 
 			fd.Data = make([]byte, len(decryptedData))
 			fd.Data = decryptedData
-			f.LogDebug(
-				fmt.Sprintf("%s: decrypted data at key %s",
-					loggerName,
-					key))
 
 			// if encryptionKey is an old key, refresh data with the latest key
 			if i > 0 {
-				f.LogDebug(
-					fmt.Sprintf(
-						"%s: rolling encryption for data at key %s",
-						loggerName,
-						key))
+				log.Println("fsvault.Get(): rolling encryption for data at key", key)
 
 				// remember, Store() takes a key not the fullPath
-				err := f.Put(key, fd.Data)
+				err := Put(key, fd.Data)
 				if err != nil {
-					f.LogDebug(
-						fmt.Sprintf("%s: failed data refresh at key %s",
-							loggerName,
-							key))
+					log.Println("fsvault.Get(): failed data refresh at key", key)
 				}
 			}
 			break

--- a/fsvault/fsvault_test.go
+++ b/fsvault/fsvault_test.go
@@ -19,37 +19,37 @@ func TestFullFilePath(t *testing.T) {
 
 	testCases := []struct {
 		description    string
-		location       string
+		datadir        string
 		key            string
 		expectFullPath string
 	}{
 		{
 			description:    "empty location string",
-			location:       "",
+			datadir:        "",
 			key:            "/some/test/key",
 			expectFullPath: "/some/test/key",
 		},
 		{
 			description:    "system root location",
-			location:       "/",
+			datadir:        "/",
 			key:            "/some/test/key",
 			expectFullPath: "/some/test/key",
 		},
 		{
 			description:    "multiple slashes in location",
-			location:       "////",
+			datadir:        "////",
 			key:            "/some/test/key",
 			expectFullPath: "/some/test/key",
 		},
 		{
 			description:    "simple trying to break out of location",
-			location:       "/data/",
+			datadir:        "/data/",
 			key:            "/../test/key",
 			expectFullPath: "/data/test/key",
 		},
 		{
 			description:    "multple .. trying to break out of location",
-			location:       "/data/",
+			datadir:        "/data/",
 			key:            "/test/../../key",
 			expectFullPath: "/data/key",
 		},
@@ -57,9 +57,8 @@ func TestFullFilePath(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		fs := FSVault{}
-		fs.location = tc.location
-		result := fs.FullFilePath(tc.key)
+		datadir = tc.datadir
+		result := fullFilePath(tc.key)
 
 		assert.Equal(t, tc.expectFullPath, result, tc.description)
 	}
@@ -67,66 +66,31 @@ func TestFullFilePath(t *testing.T) {
 }
 
 /*
-Test passing in encryption keys as args, or none.
-*/
-func TestNewFSVault(t *testing.T) {
-
-	var (
-		secretKey1 = "mylongsecdddddwwwwdtmylongsecret"
-		secretKey2 = "aaojadsnkdakndasnaddddddddddddds"
-	)
-
-	location, err := os.MkdirTemp("", "thisdougb-fsvault")
-	if err != nil {
-		assert.Fail(t, err.Error())
-	}
-	defer os.RemoveAll(location) // clean up
-
-	f := NewFSVault(location)
-	f.EnableDebug()
-	assert.Equal(t, 0, len(f.encryptionKeys), "without keys")
-
-	f = NewFSVault(location, secretKey1)
-	assert.Equal(t, 1, len(f.encryptionKeys), "with one key")
-
-	f = NewFSVault(location, secretKey1, secretKey2)
-	assert.Equal(t, 2, len(f.encryptionKeys), "with two keys")
-
-	f = NewFSVault(location, []string{secretKey1, secretKey2}...)
-	assert.Equal(t, 2, len(f.encryptionKeys), "with array of two keys")
-
-	f = NewFSVault(location, []string{""}...)
-	assert.Equal(t, 0, len(f.encryptionKeys), "empty string as a key")
-}
-
-/*
 Test if key (file and directory) exist.
 */
 func TestKeyExists(t *testing.T) {
 
-	location, err := os.MkdirTemp("", "thisdougb-fsvault")
+	testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	defer os.RemoveAll(location) // clean up
+	defer os.RemoveAll(testDataDir) // clean up
+
+	datadir = testDataDir // package var
 
 	// create the full path in order to create a file
 	key := "test_key"
-	tmpfile := filepath.Join(location, key)
+	tmpfile := filepath.Join(datadir, key)
 
 	_, err = os.Create(tmpfile)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	f := NewFSVault(location)
-	f.EnableDebug()
-
-	exists, err := f.KeyExists(key)
+	exists, err := KeyExists(key)
 
 	assert.Equal(t, true, exists, "tmpfile")
 	assert.Equal(t, nil, err, "tmpfile")
-
 }
 
 /*
@@ -150,16 +114,15 @@ func TestKeyDoesNotExist(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		location, err := os.MkdirTemp("", "thisdougb-fsvault")
+		testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 		if err != nil {
 			assert.Fail(t, err.Error())
 		}
-		defer os.RemoveAll(location) // clean up
+		defer os.RemoveAll(testDataDir) // clean up
 
-		f := NewFSVault(location)
-		f.EnableDebug()
+		datadir = testDataDir // package var
 
-		exists, err := f.KeyExists(tc.key)
+		exists, err := KeyExists(tc.key)
 
 		// the actual error includes our random-path tmpdir, so just check
 		// for the common part
@@ -208,21 +171,20 @@ func TestPut(t *testing.T) {
 		},
 	}
 
-	location, err := os.MkdirTemp("", "thisdougb-fsvault")
+	testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	defer os.RemoveAll(location) // clean up
+	defer os.RemoveAll(testDataDir) // clean up
+
+	datadir = testDataDir // package var
 
 	for _, tc := range testCases {
 
-		f := NewFSVault(location, tc.secretKeys...)
-		f.EnableDebug()
-
-		err = f.Put(tc.key, []byte(tc.data))
+		err = Put(tc.key, []byte(tc.data))
 		assert.Equal(t, tc.expectError, err, tc.description)
 
-		data, err := f.Get(tc.key)
+		data, err := Get(tc.key)
 		if err != nil {
 			assert.Fail(t, err.Error(), tc.description)
 		}
@@ -248,18 +210,19 @@ func TestInvalidKeyLength(t *testing.T) {
 		},
 	}
 
-	location, err := os.MkdirTemp("", "thisdougb-fsvault")
+	testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	defer os.RemoveAll(location) // clean up
+	defer os.RemoveAll(testDataDir) // clean up
+
+	datadir = testDataDir // package var
 
 	for _, tc := range testCases {
 
-		f := NewFSVault(location, tc.secretKeys...)
-		f.EnableDebug()
+		encryptionKeys = tc.secretKeys // package var
 
-		err = f.Put(tc.key, []byte(tc.data))
+		err = Put(tc.key, []byte(tc.data))
 		assert.Equal(t, tc.expectError, err, tc.description)
 	}
 }
@@ -274,21 +237,21 @@ func TestKeyRollover(t *testing.T) {
 		key        = "testfile"
 	)
 
-	location, err := os.MkdirTemp("", "thisdougb-fsvault")
+	testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 	if err != nil {
 		assert.Fail(t, err.Error())
 	}
-	defer os.RemoveAll(location) // clean up
+	defer os.RemoveAll(testDataDir) // clean up
+
+	datadir = testDataDir                 // package var
+	encryptionKeys = []string{secretKey1} // package var
 
 	// store encrypted data using the first key
-	f := NewFSVault(location, secretKey1)
-	f.EnableDebug()
-
-	err = f.Put(key, []byte(secretData))
+	err = Put(key, []byte(secretData))
 	assert.Equal(t, nil, err, "Put() initial content using secretKey1")
 
 	testDescription := "Get() with secretKey1"
-	data, err := f.Get(key)
+	data, err := Get(key)
 	if err != nil {
 		assert.Fail(t, err.Error(), testDescription)
 	}
@@ -297,9 +260,8 @@ func TestKeyRollover(t *testing.T) {
 	// now re-read the data and test the encryption key is rolled
 	// read with secretKey1, re-encrypt with secretKey3
 	testDescription = "Get() with rolled keys [secretKey3, secretKey2, secretKey1]"
-	f = NewFSVault(location, secretKey3, secretKey2, secretKey1)
-	f.EnableDebug()
-	data, err = f.Get(key)
+	encryptionKeys = []string{secretKey3, secretKey2, secretKey1}
+	data, err = Get(key)
 	if err != nil {
 		assert.Fail(t, err.Error(), testDescription)
 	}
@@ -307,9 +269,8 @@ func TestKeyRollover(t *testing.T) {
 
 	// now re-read the data and test key3 specifically encryption
 	testDescription = "Get() with secretKey3"
-	f = NewFSVault(location, secretKey3)
-	f.EnableDebug()
-	data, err = f.Get(key)
+	encryptionKeys = []string{secretKey3}
+	data, err = Get(key)
 	if err != nil {
 		assert.Fail(t, err.Error(), testDescription)
 	}
@@ -356,20 +317,19 @@ func TestList(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		location, err := os.MkdirTemp("", "thisdougb-fsvault")
+		testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 		if err != nil {
 			assert.Fail(t, err.Error())
 		}
-		defer os.RemoveAll(location) // clean up
+		defer os.RemoveAll(testDataDir) // clean up
 
-		f := NewFSVault(location)
-		f.EnableDebug()
+		datadir = testDataDir // package var
 
 		for _, k := range tc.createKeys {
-			f.Put(k, []byte("some data"))
+			Put(k, []byte("some data"))
 		}
 
-		list := f.List(tc.listKey)
+		list := List(tc.listKey)
 		assert.Equal(t, tc.expectList, list, tc.description)
 	}
 }
@@ -426,21 +386,20 @@ func TestDelete(t *testing.T) {
 
 	for _, tc := range testCases {
 
-		location, err := os.MkdirTemp("", "thisdougb-fsvault")
+		testDataDir, err := os.MkdirTemp("", "thisdougb-fsvault")
 		if err != nil {
 			assert.Fail(t, err.Error())
 		}
-		defer os.RemoveAll(location) // clean up
+		defer os.RemoveAll(testDataDir) // clean up
 
-		f := NewFSVault(location)
-		f.EnableDebug()
+		datadir = testDataDir // package var
 
 		for _, k := range tc.createKeys {
-			f.Put(k, []byte("some data"))
+			Put(k, []byte("some data"))
 		}
 
 		// I don't think we need to test the return error
-		f.Delete(tc.deleteKey)
-		assert.Equal(t, tc.expectList, f.List(tc.deletedParent), tc.description)
+		Delete(tc.deleteKey)
+		assert.Equal(t, tc.expectList, List(tc.deletedParent), tc.description)
 	}
 }

--- a/fsvault/init.go
+++ b/fsvault/init.go
@@ -11,9 +11,12 @@ import (
 var (
 	datadir        string // root data directory
 	encryptionKeys []string
+	keylocker      *keyLocker
 )
 
 func init() {
+
+	keylocker = newkeyLocker()
 
 	// get the root data directory, under which all keys wil be stored.
 	datadir = config.StringValue("FSVAULT_DATADIR")
@@ -30,15 +33,18 @@ func init() {
 
 func getEncryptionKeysFromEnv() []string {
 
+	keys := []string{}
+
 	keysEnvVar := config.StringValue("FSVAULT_SECRET_KEYS")
+
 	for _, k := range strings.Split(keysEnvVar, ",") {
 
 		if len(k) == 16 || len(k) == 24 || len(k) == 32 {
-			encryptionKeys = append(encryptionKeys, strings.TrimSpace(k))
+			keys = append(keys, strings.TrimSpace(k))
 		} else {
 			log.Println("fsvault.init(): invalid secret key length, ignoring", k)
 		}
 	}
 
-	return encryptionKeys
+	return keys
 }

--- a/fsvault/init.go
+++ b/fsvault/init.go
@@ -1,0 +1,44 @@
+package fsvault
+
+import (
+	"log"
+	"strings"
+
+	"github.com/thisdougb/go-fsvault/internal/config"
+)
+
+// package level vars
+var (
+	datadir        string // root data directory
+	encryptionKeys []string
+)
+
+func init() {
+
+	// get the root data directory, under which all keys wil be stored.
+	datadir = config.StringValue("FSVAULT_DATADIR")
+	log.Println("fsvault.init(): using datadir", datadir)
+
+	// try to load encryption keys from env vars
+	encryptionKeys = getEncryptionKeysFromEnv()
+	if len(encryptionKeys) > 0 {
+		log.Println("fsvault.init(): encryption enabled.")
+	} else {
+		log.Println("fsvault.init(): encryption not enabled.")
+	}
+}
+
+func getEncryptionKeysFromEnv() []string {
+
+	keysEnvVar := config.StringValue("FSVAULT_SECRET_KEYS")
+	for _, k := range strings.Split(keysEnvVar, ",") {
+
+		if len(k) == 16 || len(k) == 24 || len(k) == 32 {
+			encryptionKeys = append(encryptionKeys, strings.TrimSpace(k))
+		} else {
+			log.Println("fsvault.init(): invalid secret key length, ignoring", k)
+		}
+	}
+
+	return encryptionKeys
+}

--- a/fsvault/keylocker.go
+++ b/fsvault/keylocker.go
@@ -1,0 +1,81 @@
+package fsvault
+
+// from: https://stackoverflow.com/questions/40931373/how-to-gc-a-map-of-mutexes-in-go
+
+// Package provides locking per-key.
+// For example, you can acquire a lock for a specific user ID and all other requests for that user ID
+// will block until that entry is unlocked (effectively your work load will be run serially per-user ID),
+// and yet have work for separate user IDs happen concurrently.
+
+import (
+	"fmt"
+	"sync"
+)
+
+type keyLocker struct {
+	keymapLock sync.Mutex                   // synchronisation around the keymap
+	keymap     map[interface{}]*keymapEntry // keymap holds the individual key locks
+}
+
+type keymapEntry struct {
+	keymap    *keyLocker  // point back to keyLocker, so we can synchronize removing this mentry when cnt==0
+	entryLock sync.Mutex  // entry-specific lock
+	cnt       int         // reference count
+	key       interface{} // key in keymap, may be string, int, etc.
+}
+
+// Unlocker provides an Unlock method to release the lock.
+type Unlocker interface {
+	Unlock()
+}
+
+// New returns an initalized keyLocker.
+func newkeyLocker() *keyLocker {
+	return &keyLocker{keymap: make(map[interface{}]*keymapEntry)}
+}
+
+// lock acquires a lock corresponding to this key.
+// This method will never return nil and Unlock() must be called
+// to release the lock when done.
+func (kl *keyLocker) lock(key interface{}) Unlocker {
+
+	// read or create entry for this key atomically
+	kl.keymapLock.Lock()
+	entry, ok := kl.keymap[key]
+	if !ok {
+		entry = &keymapEntry{keymap: kl, key: key}
+		kl.keymap[key] = entry
+	}
+	entry.cnt++ // ref count
+	kl.keymapLock.Unlock()
+
+	// acquire lock, will block here until e.cnt==1
+	entry.entryLock.Lock()
+
+	return entry
+}
+
+// Unlock releases the lock for this entry.
+func (entry *keymapEntry) Unlock() {
+
+	kl := entry.keymap
+
+	// lock the keyLocker map
+	kl.keymapLock.Lock()
+
+	// decrement and if needed remove entry atomically
+	e, ok := kl.keymap[entry.key]
+	if !ok { // entry must exist
+		kl.keymapLock.Unlock()
+		panic(fmt.Errorf("Unlock requested for key=%v but no entry found", entry.key))
+	}
+	e.cnt--        // ref count
+	if e.cnt < 1 { // if it hits zero then we own it and remove from map
+		delete(kl.keymap, entry.key)
+	}
+	kl.keymapLock.Unlock()
+
+	// now that map stuff is handled, we unlock and let
+	// anything else waiting on this key through
+	entry.entryLock.Unlock()
+}

--- a/fsvcli/main.go
+++ b/fsvcli/main.go
@@ -11,14 +11,13 @@ import (
 )
 
 var (
-	cfg            *config.Config
 	encryptionKeys []string
 	location       string
 )
 
 func init() {
 	encryptionKeys = getEncryptionKeysFromEnv()
-	location = cfg.ValueAsStr("FSVAULT_PATH")
+	location = config.StringValue("FSVAULT_DATADIR")
 }
 
 /*
@@ -232,7 +231,7 @@ func listDataAtKey(key string, debug bool) error {
 
 func getEncryptionKeysFromEnv() []string {
 
-	keysEnvVar := cfg.ValueAsStr("FSVAULT_SECRET_KEYS")
+	keysEnvVar := config.StringValue("FSVAULT_SECRET_KEYS")
 	for _, k := range strings.Split(keysEnvVar, ",") {
 		encryptionKeys = append(encryptionKeys, strings.TrimSpace(k))
 	}

--- a/fsvcli/main.go
+++ b/fsvcli/main.go
@@ -5,21 +5,9 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"strings"
 
 	"github.com/thisdougb/go-fsvault/fsvault"
-	"github.com/thisdougb/go-fsvault/internal/config"
 )
-
-var (
-	encryptionKeys []string
-	datadir        string
-)
-
-func init() {
-	encryptionKeys = getEncryptionKeysFromEnv()
-	datadir = config.StringValue("FSVAULT_DATADIR")
-}
 
 /*
 fsvcli provides a command line interface to an fsvault datastore.
@@ -175,19 +163,4 @@ func listDataAtKey(key string) error {
 	}
 
 	return nil
-}
-
-func getEncryptionKeysFromEnv() []string {
-
-	keysEnvVar := config.StringValue("FSVAULT_SECRET_KEYS")
-	for _, k := range strings.Split(keysEnvVar, ",") {
-
-		if len(k) == 16 || len(k) == 24 || len(k) == 32 {
-			encryptionKeys = append(encryptionKeys, strings.TrimSpace(k))
-		} else {
-			log.Println("fsvault.init(): invalid secret key length, ignoring", k)
-		}
-	}
-
-	return encryptionKeys
 }

--- a/internal/config/main.go
+++ b/internal/config/main.go
@@ -5,43 +5,38 @@ import (
 	"strconv"
 )
 
-// Config holding struct
-type Config struct{}
-
 var defaultValues = map[string]interface{}{
-	"FSVAULT_PATH":        "/tmp",
+	"FSVAULT_DATADIR":     "/tmp",
 	"FSVAULT_SECRET_KEYS": "",
 }
 
-// ValueAsStr gets a string value from the env or default
-func (c *Config) ValueAsStr(key string) string {
-
+func StringValue(key string) string {
 	if defaultValue, ok := defaultValues[key]; ok {
-		return c.getEnvVar(key, defaultValue.(string)).(string)
+		return getEnvVar(key, defaultValue.(string)).(string)
 	}
 	return ""
 }
 
 // ValueAsInt gets a string value from the env or default
-func (c *Config) ValueAsInt(key string) int {
+func IntValue(key string) int {
 
 	if defaultValue, ok := defaultValues[key]; ok {
-		return c.getEnvVar(key, defaultValue.(int)).(int)
+		return getEnvVar(key, defaultValue.(int)).(int)
 	}
 	return 0
 }
 
 // ValueAsBool gets a string value from the env or default
-func (c *Config) ValueAsBool(key string) bool {
+func BoolValue(key string) bool {
 
 	if defaultValue, ok := defaultValues[key]; ok {
-		return c.getEnvVar(key, defaultValue.(bool)).(bool)
+		return getEnvVar(key, defaultValue.(bool)).(bool)
 	}
 	return false
 }
 
 // Private methods here
-func (c *Config) getEnvVar(key string, fallback interface{}) interface{} {
+func getEnvVar(key string, fallback interface{}) interface{} {
 
 	value, exists := os.LookupEnv(key)
 	if !exists {

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -18,94 +18,86 @@ func init() {
 }
 
 // Test string value type
-func TestValueAsStr(t *testing.T) {
-
-	var cfg *Config // dynamic config settings
+func TestStringValue(t *testing.T) {
 
 	// test: unset potential env var, this should return the Str value in defaultValue[map]
 	os.Unsetenv("_TEST_STR_VALUE")
-	assert.Equal(t, "AAA", cfg.ValueAsStr("_TEST_STR_VALUE"), "no env var set")
+	assert.Equal(t, "AAA", StringValue("_TEST_STR_VALUE"), "no env var set")
 
 	// test: now override the defaultValue[map] using an env var value
 	os.Setenv("_TEST_STR_VALUE", "hello")
-	assert.Equal(t, "hello", cfg.ValueAsStr("_TEST_STR_VALUE"), "env var set")
+	assert.Equal(t, "hello", StringValue("_TEST_STR_VALUE"), "env var set")
 	os.Unsetenv("_TEST_STR_VALUE")
 
 	// test: non-existing key
-	assert.Equal(t, "", cfg.ValueAsStr("_TEST_STR_NOKEY"), "no key configured")
+	assert.Equal(t, "", StringValue("_TEST_STR_NOKEY"), "no key configured")
 }
 
 // Test int value type
 func TestValueAsInt(t *testing.T) {
 
-	var cfg *Config // dynamic config settings
-
 	// test: unset potential env var, this should return the int value in defaultValue[map]
 	os.Unsetenv("_TEST_INT_VALUE")
-	assert.Equal(t, 10, cfg.ValueAsInt("_TEST_INT_VALUE"), "no env var set")
+	assert.Equal(t, 10, IntValue("_TEST_INT_VALUE"), "no env var set")
 
 	// test: now override the defaultValue[map] using an env var value
 	os.Setenv("_TEST_INT_VALUE", "20")
-	assert.Equal(t, 20, cfg.ValueAsInt("_TEST_INT_VALUE"), "env var set")
+	assert.Equal(t, 20, IntValue("_TEST_INT_VALUE"), "env var set")
 	os.Unsetenv("_TEST_INT_VALUE")
 
 	// test: now we use a non-int env var, which should be ignored
 	os.Setenv("_TEST_INT_VALUE", ";")
-	assert.Equal(t, 10, cfg.ValueAsInt("_TEST_INT_VALUE"), "env var not int")
+	assert.Equal(t, 10, IntValue("_TEST_INT_VALUE"), "env var not int")
 	os.Unsetenv("_TEST_INT_VALUE")
 
 	// test: non-existing key
-	assert.Equal(t, 0, cfg.ValueAsInt("_TEST_INT_NOKEY"), "no key configured")
+	assert.Equal(t, 0, IntValue("_TEST_INT_NOKEY"), "no key configured")
 }
 
 // Test bool value type
 func TestValueAsBool(t *testing.T) {
 
-	var cfg *Config // dynamic config settings
-
 	// test: unset potential env var, this should return the int value in defaultValue[map]
 	os.Unsetenv("_TEST_BOOL_VALUE")
-	assert.Equal(t, false, cfg.ValueAsBool("_TEST_BOOL_VALUE"), "no env var set")
+	assert.Equal(t, false, BoolValue("_TEST_BOOL_VALUE"), "no env var set")
 
 	// test: now override the defaultValue[map] using an env var value
 	os.Setenv("_TEST_BOOL_VALUE", "true")
-	assert.Equal(t, true, cfg.ValueAsBool("_TEST_BOOL_VALUE"), "env var set")
+	assert.Equal(t, true, BoolValue("_TEST_BOOL_VALUE"), "env var set")
 	os.Unsetenv("_TEST_BOOL_VALUE")
 
 	// test: now we use a non-int env var, which should be ignored
 	os.Setenv("_TEST_BOOL_VALUE", "hello")
-	assert.Equal(t, false, cfg.ValueAsBool("_TEST_BOOL_VALUE"), "env var not int")
+	assert.Equal(t, false, BoolValue("_TEST_BOOL_VALUE"), "env var not int")
 	os.Unsetenv("_TEST_BOOL_VALUE")
 
 	// test: non-existing key
-	assert.Equal(t, false, cfg.ValueAsBool("_TEST_BOOL_NOKEY"), "no key configured")
+	assert.Equal(t, false, BoolValue("_TEST_BOOL_NOKEY"), "no key configured")
 }
 
 func TestGetEnvVar(t *testing.T) {
 
-	var cfg *Config // dynamic config settings
-
 	// test: when we set a str env var, should should get that value
 	os.Setenv("_TEST_STR_NEW", "isset")
-	assert.Equal(t, "isset", cfg.getEnvVar("_TEST_STR_NEW", "isset"), "_TEST_STR_NEW")
+	assert.Equal(t, "isset", getEnvVar("_TEST_STR_NEW", "isset"), "_TEST_STR_NEW")
 	os.Unsetenv("_TEST_STR_NEW")
 
 	// test: when no env var exists we should use the fallback value in 2nd arg
-	assert.Equal(t, "fallback", cfg.getEnvVar("_TEST_STR_NEW", "fallback"), "_TEST_STR_NEW")
+	assert.Equal(t, "fallback", getEnvVar("_TEST_STR_NEW", "fallback"), "_TEST_STR_NEW")
 
 	// test: when we set an int env var, should should get that value
 	os.Setenv("_TEST_INT_NEW", "32")
-	assert.Equal(t, 32, cfg.getEnvVar("_TEST_INT_NEW", 1), "_TEST_INT_NEW")
+	assert.Equal(t, 32, getEnvVar("_TEST_INT_NEW", 1), "_TEST_INT_NEW")
 	os.Unsetenv("_TEST_INT_NEW")
 
 	// test: when we set an bool env var, should should get that value
 	os.Setenv("_TEST_BOOL_NEW", "true")
-	assert.Equal(t, true, cfg.getEnvVar("_TEST_BOOL_NEW", false), "_TEST_BOOL_NEW")
+	assert.Equal(t, true, getEnvVar("_TEST_BOOL_NEW", false), "_TEST_BOOL_NEW")
 	os.Unsetenv("_TEST_BOOL_NEW")
 
 	// test: when we set a non-int env var, should should get the fallback value
 	// this is because we don't convert non-int automatically in getEnvVar
 	os.Setenv("TEST_UNKNOWN", "2.2")
-	assert.Equal(t, 1.1, cfg.getEnvVar("TEST_UNKNOWN", 1.1), "TEST_UNKNOWN")
+	assert.Equal(t, 1.1, getEnvVar("TEST_UNKNOWN", 1.1), "TEST_UNKNOWN")
 	os.Unsetenv("TEST_UNKNOWN")
 }


### PR DESCRIPTION
Implement key level locking in FSVault, to simplify calling packages that would otherwise have to implement locking. This is the equivalent or database row-level locking.

- [x] Refactor to typeless

Remove FSVault type, to allow integration of generic map methods. Doing this now to avoid refactoring this key locker code again.

- [x] Add keylocker method

Copy of method I use elsewhere, a map of keys pointing to locks. Individual lock to a key is released by the calling function.

- [x] Return a simple unlock object

Returns a pointer easily used in `defer`

- [x] Add example code in sub package

Simple example showing usage.

Add a new package `example` to show usage, and also test external usage.